### PR TITLE
Fix storage config file path for store-gateway and compactor

### DIFF
--- a/2-lts/step3.md
+++ b/2-lts/step3.md
@@ -30,7 +30,7 @@ You can read more about [Store](https://thanos.io/tip/components/store.md/) here
 
 ```
 docker run -d --net=host --rm \
-    -v /root/editor/bucket_storage.yaml:/etc/thanos/minio-bucket.yaml \
+    -v $(pwd)/bucket_storage.yaml:/etc/thanos/minio-bucket.yaml \
     --name store-gateway \
     quay.io/thanos/thanos:v0.28.0 \
     store \

--- a/2-lts/step4.md
+++ b/2-lts/step4.md
@@ -23,7 +23,7 @@ Click below snippet to start the Compactor.
 
 ```
 docker run -d --net=host --rm \
- -v /root/editor/bucket_storage.yaml:/etc/thanos/minio-bucket.yaml \
+ -v $(pwd)/bucket_storage.yaml:/etc/thanos/minio-bucket.yaml \
     --name thanos-compact \
     quay.io/thanos/thanos:v0.28.0 \
     compact \

--- a/3-receiver/step1.md
+++ b/3-receiver/step1.md
@@ -38,7 +38,7 @@ Run the prometheus instance:
 
 ```
 docker run -d --net=host --rm \
-    -v /root/editor/prometheus-batcave.yaml:/etc/prometheus/prometheus.yaml \
+    -v $(pwd)/prometheus-batcave.yaml:/etc/prometheus/prometheus.yaml \
     -v /root/prometheus-batcave-data:/prometheus \
     -u root \
     --name prometheus-batcave \
@@ -82,7 +82,7 @@ scrape_configs:
 
 ```
 docker run -d --net=host --rm \
-    -v /root/editor/prometheus-batcomputer.yaml:/etc/prometheus/prometheus.yaml \
+    -v $(pwd)/prometheus-batcomputer.yaml:/etc/prometheus/prometheus.yaml \
     -v /root/prometheus-batcomputer:/prometheus \
     -u root \
     --name prometheus-batcomputer \


### PR DESCRIPTION
The path for the storage specified while running store-gateway and compactor is not correct. 
The file exists in current directory but is expected under `/etc/edtor`. This results in the containers
quietly failing in the background, which store not showing up in the Query UI