### PR TITLE
1-globalview: bump prometheus and thanos version

### DIFF
--- a/1-globalview/courseBase.sh
+++ b/1-globalview/courseBase.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 docker pull quay.io/prometheus/prometheus:v2.49.1
-docker pull quay.io/thanos/thanos:v0.28.0
+docker pull quay.io/thanos/thanos:v0.34.0

--- a/1-globalview/courseBase.sh
+++ b/1-globalview/courseBase.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-docker pull quay.io/prometheus/prometheus:v2.38.0
+docker pull quay.io/prometheus/prometheus:v2.49.1
 docker pull quay.io/thanos/thanos:v0.28.0

--- a/1-globalview/step1.md
+++ b/1-globalview/step1.md
@@ -105,7 +105,7 @@ docker run -d --net=host --rm \
     -v $(pwd)/prometheus0_eu1_data:/prometheus \
     -u root \
     --name prometheus-0-eu1 \
-    quay.io/prometheus/prometheus:v2.38.0 \
+    quay.io/prometheus/prometheus:v2.49.1 \
     --config.file=/etc/prometheus/prometheus.yml \
     --storage.tsdb.path=/prometheus \
     --web.listen-address=:9090 \
@@ -124,7 +124,7 @@ docker run -d --net=host --rm \
     -v $(pwd)/prometheus0_us1_data:/prometheus \
     -u root \
     --name prometheus-0-us1 \
-    quay.io/prometheus/prometheus:v2.38.0 \
+    quay.io/prometheus/prometheus:v2.49.1 \
     --config.file=/etc/prometheus/prometheus.yml \
     --storage.tsdb.path=/prometheus \
     --web.listen-address=:9091 \
@@ -141,7 +141,7 @@ docker run -d --net=host --rm \
     -v $(pwd)/prometheus1_us1_data:/prometheus \
     -u root \
     --name prometheus-1-us1 \
-    quay.io/prometheus/prometheus:v2.38.0 \
+    quay.io/prometheus/prometheus:v2.49.1 \
     --config.file=/etc/prometheus/prometheus.yml \
     --storage.tsdb.path=/prometheus \
     --web.listen-address=:9092 \

--- a/1-globalview/step2.md
+++ b/1-globalview/step2.md
@@ -10,7 +10,7 @@ component and can be invoked in a single command.
 Let's take a look at all the Thanos commands:
 
 ```
-docker run --rm quay.io/thanos/thanos:v0.28.0 --help
+docker run --rm quay.io/thanos/thanos:v0.34.0 --help
 ```{{execute}}
 
 You should see multiple commands that solves different purposes.
@@ -53,7 +53,7 @@ docker run -d --net=host --rm \
     -v $(pwd)/prometheus0_eu1.yml:/etc/prometheus/prometheus.yml \
     --name prometheus-0-sidecar-eu1 \
     -u root \
-    quay.io/thanos/thanos:v0.28.0 \
+    quay.io/thanos/thanos:v0.34.0 \
     sidecar \
     --http-address 0.0.0.0:19090 \
     --grpc-address 0.0.0.0:19190 \
@@ -68,7 +68,7 @@ docker run -d --net=host --rm \
     -v $(pwd)/prometheus0_us1.yml:/etc/prometheus/prometheus.yml \
     --name prometheus-0-sidecar-us1 \
     -u root \
-    quay.io/thanos/thanos:v0.28.0 \
+    quay.io/thanos/thanos:v0.34.0 \
     sidecar \
     --http-address 0.0.0.0:19091 \
     --grpc-address 0.0.0.0:19191 \
@@ -81,7 +81,7 @@ docker run -d --net=host --rm \
     -v $(pwd)/prometheus1_us1.yml:/etc/prometheus/prometheus.yml \
     --name prometheus-1-sidecar-us1 \
     -u root \
-    quay.io/thanos/thanos:v0.28.0 \
+    quay.io/thanos/thanos:v0.34.0 \
     sidecar \
     --http-address 0.0.0.0:19092 \
     --grpc-address 0.0.0.0:19192 \


### PR DESCRIPTION
For tutorial 1-globalview bump Prometheus and Thanos image tags to current latest:

- prometheus:v2.49.1
- thanos:v0.34.0

I tested the tutorial with mentioned versions and it worked as it did before.